### PR TITLE
Fix compatibility issue with wp-native-php-sessions

### DIFF
--- a/src/includes/front-end-functions.php
+++ b/src/includes/front-end-functions.php
@@ -33,6 +33,10 @@
  *
 **/
 function br_rc_start_session() {
+    if ( defined( 'PANTHEON_SESSIONS_ENABLED' ) ) :
+        return;
+    endif;
+
     if ( !session_id() ) :
 
     	// Disble cache to prevent form resubmission error


### PR DESCRIPTION
wp-native-php-sessions already provides the needed session_start and conflicts with this plugin's timing of executing the session_start function (even when wp-native-php-sessions is in the mu-plugins folder and this plugin is in the normal plugins folder). This patch prevents session_start from happening too early if wp-native-php-sessions is present.